### PR TITLE
Bump to NLPModels 0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-NLPModels = "0.14"
+NLPModels = "0.15"
 julia = "^1.3.0"
 
 [extras]

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -74,11 +74,10 @@ end
 
 function GenericExecutionStats(
   status::Symbol,
-  nlp::AbstractNLPModel;
-  solution::V = eltype(nlp.meta.x0)[],
+  nlp::AbstractNLPModel{T, S};
+  solution::V = T[],
   kwargs...,
-) where {V}
-  T = eltype(solution)
+) where {S, T, V}
   return GenericExecutionStats{T, V}(status, nlp; solution = solution, kwargs...)
 end
 

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -48,7 +48,7 @@ function test_stats()
       @test typeof(stats.dual_feas) == T
       @test typeof(stats.primal_feas) == T
 
-      nlp = ADNLPModel(x -> dot(x, x), ones(T, 2), x -> [sum(x) - 1], [0.0], [0.0])
+      nlp = ADNLPModel(x -> dot(x, x), ones(T, 2), x -> [sum(x) - 1], T[0], T[0])
 
       stats = GenericExecutionStats(:first_order, nlp)
       @test stats.status == :first_order
@@ -78,7 +78,7 @@ function test_stats()
       @test eltype(stats.multipliers_L) == T
       @test eltype(stats.multipliers_U) == T
 
-      nlp = ADNLPModel(x -> dot(x, x), ones(T, 2), x -> [sum(x) - 1], [0.0], [0.0])
+      nlp = ADNLPModel(x -> dot(x, x), ones(T, 2), x -> [sum(x) - 1], T[0], T[0])
 
       with_logger(NullLogger()) do
         stats = dummy_solver(nlp)


### PR DESCRIPTION
Follows [NLPModels.jl PR #353](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/353) with parametric meta.
The tests were breaking so I had to let go on 0.14.